### PR TITLE
Fixed bug, added features, changed output comments

### DIFF
--- a/lcm-rust/lcm-gen/src/lib.rs
+++ b/lcm-rust/lcm-gen/src/lib.rs
@@ -32,6 +32,7 @@ use std::process::Command;
 pub struct LcmGen {
     files: Vec<PathBuf>,
     out_dir: PathBuf,
+    rustdoc: bool,
 }
 
 impl LcmGen {
@@ -40,6 +41,7 @@ impl LcmGen {
         LcmGen {
             files: Vec::new(),
             out_dir: env::var("OUT_DIR").unwrap().into(),
+            rustdoc: false,
         }
     }
 
@@ -67,6 +69,12 @@ impl LcmGen {
         self
     }
 
+    /// Sets whether file should use rustdoc style documentation
+    pub fn use_rustdoc(&mut self, rustdoc: bool) -> &Self {
+        self.rustdoc = rustdoc;
+        self
+    }
+
     /// Runs `lcm-gen --rust --rust-path={}` on each `.lcm` file that was added.
     pub fn run(&self) {
         // Rerun if the lcm-gen binary changes
@@ -82,6 +90,9 @@ impl LcmGen {
         let mut cmd = Command::new("lcm-gen");
         cmd.arg("--rust")
             .arg(format!("--rust-path={}", self.out_dir.display()));
+        if self.rustdoc {
+            cmd.arg("--rustdoc");
+        }
         for path in &self.files {
             println!("cargo:rerun-if-changed={}", path.display());
             cmd.arg(path);

--- a/lcm-rust/lcm-gen/src/lib.rs
+++ b/lcm-rust/lcm-gen/src/lib.rs
@@ -32,7 +32,6 @@ use std::process::Command;
 pub struct LcmGen {
     files: Vec<PathBuf>,
     out_dir: PathBuf,
-    rustdoc: bool,
 }
 
 impl LcmGen {
@@ -41,7 +40,6 @@ impl LcmGen {
         LcmGen {
             files: Vec::new(),
             out_dir: env::var("OUT_DIR").unwrap().into(),
-            rustdoc: false,
         }
     }
 
@@ -69,12 +67,6 @@ impl LcmGen {
         self
     }
 
-    /// Sets whether file should use rustdoc style documentation
-    pub fn use_rustdoc(&mut self, rustdoc: bool) -> &Self {
-        self.rustdoc = rustdoc;
-        self
-    }
-
     /// Runs `lcm-gen --rust --rust-path={}` on each `.lcm` file that was added.
     pub fn run(&self) {
         // Rerun if the lcm-gen binary changes
@@ -90,9 +82,6 @@ impl LcmGen {
         let mut cmd = Command::new("lcm-gen");
         cmd.arg("--rust")
             .arg(format!("--rust-path={}", self.out_dir.display()));
-        if self.rustdoc {
-            cmd.arg("--rustdoc");
-        }
         for path in &self.files {
             println!("cargo:rerun-if-changed={}", path.display());
             cmd.arg(path);

--- a/lcmgen/emit_rust.c
+++ b/lcmgen/emit_rust.c
@@ -63,7 +63,7 @@ static char* make_rust_mod_file_name(const char* prefix, const lcm_struct_t* lcm
     strcat(result, prefix);
     strcat(result, "/");
     strcat(result, package_name);
-    for (char* c = result; *c != 0; ++c) {
+    for (char* c = result + strlen(prefix); *c != 0; ++c) {
         if (*c == '.') {
             *c = '/';
         }


### PR DESCRIPTION
# The Bug

There was a bug where "rust-path" was required to be an absolute path. This came from `make_rust_mod_file_name`: it included the prefix when replacing '.' with '.', meaning "./mod.type" became "//mod/type" instead of "./mod/type".

# The Features

## Non-Primitive `use`
Non-primitive types were not correctly being `use`'d. They still aren't, but I think assuming they're in a shared parent module is safer than doing nothing. Though I do see a good argument for the way it was before: Until "mod_path!" is included in std, most people will probably just "include!" the file which means that the `use` issue can be fixed in that file. But, as a counter argument, "mod_path!" may become std, it is already available as a crate, and my assumption will be true if people use it.

## Rustdoc
Comments were being generated as C-style `/* ... */` comments. From my own personal use and looking at the C++ version, it seems that generating Rustdoc style comments could be better. It allows the structs to be better represented in the documentation and, if the user doesn't want that, they can be hidden via `#[doc(hidden)]`.

As a side node, it does not appear the comments are correctly generated for anything but the struct. Members and constants do not have output comments. But, based on the C++ version, it appears that isn't a Rust-specific problem.

## Constants
Constants are now emitted.

Struct affiliated types (which, if I understand correctly, would be Rust's version of static member constants) are currently unstable, which left me with three options:
1. Returned from a static member function
    * Keeps roughly the same structure as everything else emitted by LCM
    * Any half-decent compiler will eliminate the function call
    * But they can't be used in const expressions
        * But that seems like an uncommon use-case
2. As constants in the mod
    * Keeps almost the same structure as everything else
    * They are actually constants
    * Might be name collisions if two structs in the same mod have similarly named constants
3. Put everything in a submod
    * Constants can be actual constants
    * Keeps roughly the same structure for constants as other languages
    * Does not keep same structure for the struct itself
        * Unless a 'pub use foo::Foo' is included
        * Which either means we have to `pub use` the constants (now same issues as option 2) or make the submod pub, but then there are two ways to access the struct

I elected to go with option 1 for this pull request. Option 2 seems like the worst choice, and I can see plenty argument for option 3.

# lcm_rust
Technically this changes the behavior of lcm_rust, but I don't know how that should be reflected in version information. Particularly since the lcm_rust compiled from Crates.io doesn't necessarily have to match the version of LCM that is installed.

