### PR TITLE
Vector lengths are checked against size member

### DIFF
--- a/lcm-rust/lcm/src/lcm.rs
+++ b/lcm-rust/lcm/src/lcm.rs
@@ -227,26 +227,28 @@ impl Drop for Lcm {
 
 
 
+#[cfg(test)]
 ///
 /// Tests
 ///
+mod test {
+    #[test]
+    fn initialized() {
+        let _lcm = Lcm::new().unwrap();
+    }
 
-#[test]
-fn initialized() {
-    let _lcm = Lcm::new().unwrap();
-}
+    #[test]
+    fn test_subscribe() {
+        let mut lcm = Lcm::new().unwrap();
+        lcm.subscribe("channel", |_: String| {});
+        assert_eq!(lcm.subscriptions.len(), 1);
+    }
 
-#[test]
-fn test_subscribe() {
-    let mut lcm = Lcm::new().unwrap();
-    lcm.subscribe("channel", |_: String| {});
-    assert_eq!(lcm.subscriptions.len(), 1);
-}
-
-#[test]
-fn test_unsubscribe() {
-    let mut lcm = Lcm::new().unwrap();
-    let sub = lcm.subscribe("channel", |_: String| {});
-    lcm.unsubscribe(sub).unwrap();
-    assert_eq!(lcm.subscriptions.len(), 0);
+    #[test]
+    fn test_unsubscribe() {
+        let mut lcm = Lcm::new().unwrap();
+        let sub = lcm.subscribe("channel", |_: String| {});
+        lcm.unsubscribe(sub).unwrap();
+        assert_eq!(lcm.subscriptions.len(), 0);
+    }
 }

--- a/lcm-rust/lcm/src/lib.rs
+++ b/lcm-rust/lcm/src/lib.rs
@@ -21,6 +21,7 @@ macro_rules! trace { ($($a:tt)*) => ( () ) }
 macro_rules! error { ($($a:tt)*) => ( () ) }
 
 mod ffi;
+
 mod lcm;
 pub use lcm::Lcm;
 

--- a/lcmgen/emit_rust.c
+++ b/lcmgen/emit_rust.c
@@ -278,7 +278,7 @@ static void emit_header_start(lcmgen_t *lcmgen, FILE *f)
     emit(0, "// GENERATED CODE - DO NOT EDIT");
     emit(0, "");
     emit(0, "use lcm::Message;");
-    emit(0, "use std::io::{Result, Read, Write};");
+    emit(0, "use std::io::{Result, ErrorKind, Read, Write};");
 }
 
 static void emit_struct_def(lcmgen_t *lcmgen, FILE *f, lcm_struct_t *lcm_struct)

--- a/lcmgen/emit_rust.c
+++ b/lcmgen/emit_rust.c
@@ -185,23 +185,6 @@ static char * make_rustdoc_comment(const char *comment) {
     return result;
 }
 
-static const char * dim_size_prefix(const char *dim_size) {
-    char *eptr = NULL;
-    long asdf = strtol(dim_size, &eptr, 0);
-    (void) asdf;  // suppress compiler warnings
-    if(*eptr == '\0')
-        return "";
-    else
-        return "self.";
-}
-
-static int is_dim_size_fixed(const char* dim_size) {
-    char *eptr = NULL;
-    long asdf = strtol(dim_size, &eptr, 0);
-    (void) asdf;  // suppress compiler warnings
-    return (*eptr == '\0');
-}
-
 static char *map_lcm_primitive(const char *typename)
 {
     if (!strcmp(typename, "boolean"))
@@ -419,11 +402,14 @@ static void emit_impl_message_encode(FILE *f, lcm_struct_t *lcm_struct) {
         emit(2, "let item = &self.%s;", member->membername);
         for (unsigned int d = 0; d != ndim; ++d) {
             lcm_dimension_t *dimension = (lcm_dimension_t *) g_ptr_array_index(member->dimensions, d);
-            const char *prefix = dim_size_prefix(dimension->size);
-            emit(2+d, "let a%d = if %s%s > item.len() {", d, prefix, dimension->size);
-            emit(2+d+1,    "return Err(Error::new(ErrorKind::Other, \"Size is larger than vector\"));");
-            emit(2+d, "} else { %s%s };", prefix, dimension->size);
-            emit(2+d, "for item in item.iter().take(a%d) {", d);
+            if (dimension->mode == LCM_VAR) {
+                emit(2+d, "if self.%s > item.len() {", dimension->size);
+                emit(2+d+1,    "return Err(Error::new(ErrorKind::Other, \"Size is larger than vector\"));");
+                emit(2+d, "};");
+                emit(2+d, "for item in item.iter().take(self.%s as usize) {", dimension->size);
+            } else {
+                emit(2+d, "for item in item.iter() {");
+            }
         }
         emit(2+ndim, "item.encode(&mut buffer)?;");
         for (unsigned int d = ndim; d-- != 0; ) {


### PR DESCRIPTION
Closes #3

The C++ blindly follows the size member, which means that (1) undefined behavior happens if the member is larger than the size of the vector and (2) it is possible to send only part of the vector in the message.

Since (2) seems potentially useful, that behavior still exists. Instead of (1), the function now returns an `Err` if the vector is too small.