### PR TITLE
Added "license" field, removed "license-file"

### DIFF
--- a/lcm-rust/lcm-gen/Cargo.toml
+++ b/lcm-rust/lcm-gen/Cargo.toml
@@ -6,7 +6,7 @@ description = "Build dependency to invoke lcm-gen"
 documentation = "https://docs.rs/crate/lcm_gen"
 homepage = "https://github.com/adeschamps/lcm/tree/rust/lcm-rust/lcm-gen"
 repository = "https://github.com/adeschamps/lcm/tree/rust/lcm-rust/lcm-gen"
-license-file = "../../COPYING"
+license = "LGPL-2.1"
 categories = ["api-bindings", "external-ffi-bindings", "encoding"]
 
 [dependencies]

--- a/lcm-rust/lcm/Cargo.toml
+++ b/lcm-rust/lcm/Cargo.toml
@@ -6,7 +6,7 @@ description = "Rust bindings for the LCM library"
 documentation = "https://docs.rs/crate/lcm"
 homepage = "https://github.com/adeschamps/lcm/tree/rust/lcm-rust/lcm"
 repository = "https://github.com/adeschamps/lcm/tree/rust/lcm-rust/lcm"
-license-file = "../../COPYING"
+license = "LGPL-2.1"
 categories = ["api-bindings", "external-ffi-bindings", "encoding"]
 
 [dependencies]


### PR DESCRIPTION
Closes #10.

As far as I can tell, LCM uses the LGPL-2.1 license with zero modifications to the license file. Specifying that as the license instead using a license file allows tools like [cargo-license](https://crates.io/crates/cargo-license) to work correctly.