### PR TITLE
Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: rust
+script:
+  - rustc --version && cargo --version
+  - cmake .
+  - make
+  - cd lcm-rust/lcm
+  - cargo build --verbose
+  - cargo test --verbose
+  -  cd ../lcm-gen
+  - cargo build --verbose
+  - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,16 @@ matrix:
   allow_failures:
     - rust: nightly
 
+sudo: required
+
 install:
   - wget -qO- http://www.cmake.org/files/v3.1/cmake-3.1.0-Linux-x86_64.tar.gz | tar xvz
   - sudo cp -fR cmake-3.1.0-Linux-x86_64/* /usr
 
 script:
   - cmake .
-  - make install
+  - make
+  - sudo make install
   - cd lcm-rust/lcm
   - cargo build --verbose
   - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
 language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+
+install:
+  - wget -qO- http://www.cmake.org/files/v3.1/cmake-3.1.0-Linux-x86_64.tar.gz | tar xvz
+  - sudo cp -fR cmake-3.1.0-Linux-x86_64/* /usr
+
 script:
-  - rustc --version && cargo --version
   - cmake .
   - make
   - cd lcm-rust/lcm

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ script:
   - cmake .
   - make
   - sudo make install
+  - export LD_LIBRARY_PATH="$(pwd)/lcm:$(LD_LIBRARY_PATH)"
+  - export LIBRARY_PATH="$(pwd)/lcm:$(LIBRARY_PATH)"
   - cd lcm-rust/lcm
   - cargo build --verbose
   - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 
 script:
   - cmake .
-  - make
+  - make install
   - cd lcm-rust/lcm
   - cargo build --verbose
   - cargo test --verbose


### PR DESCRIPTION
Closes #2 

I had to fork the project in order to add it to Travis CI. Once it's set up for this repository, the configuration file should work.

The `sudo make install` line is somewhat broken - it allows lcm-rust to build but there is an error at runtime. Hence the environment variables.