### PR TITLE
Make lcm::Lcm Sync + Send

### DIFF
--- a/lcm-rust/lcm/examples/publisher.rs
+++ b/lcm-rust/lcm/examples/publisher.rs
@@ -3,6 +3,6 @@ use lcm::Lcm;
 
 fn main()
 {
-	let mut lcm = Lcm::new().unwrap();
+	let lcm = Lcm::new().unwrap();
 	lcm.publish("example", &"Hello, World!".to_string()).unwrap();
 }

--- a/lcm-rust/lcm/examples/subscriber.rs
+++ b/lcm-rust/lcm/examples/subscriber.rs
@@ -3,7 +3,7 @@ use lcm::Lcm;
 
 fn main()
 {
-	let mut lcm = Lcm::new().unwrap();
+	let lcm = Lcm::new().unwrap();
 	lcm.subscribe("example", |msg: String| println!("Message: {}", msg) );
 
 	loop { lcm.handle().unwrap(); }


### PR DESCRIPTION
The C and C++ versions of LCM are thread safe while the current implementation of lcm-rust is not. I am of the opinion that this won't be ready to be merged into the main repo until that is fixed (#6).

It hasn't been thoroughly tested, but I think this should be a correct fix. The underlying `lcm_t` is already thread safe, so I believe that the only thing that needs to be protected is the `Vec` containing the subscriptions. I'm also fairly confident that the closures only need to be `Send` (and not `Sync`) since there will only ever be one thread accessing them.