### PR TITLE
Convert errors/results to our own type using error-chain.

### DIFF
--- a/lcm-rust/lcm/Cargo.toml
+++ b/lcm-rust/lcm/Cargo.toml
@@ -11,4 +11,5 @@ categories = ["api-bindings", "external-ffi-bindings", "encoding"]
 
 [dependencies]
 byteorder = "0.5"
+error-chain = "0.10"
 log = { version = "0.3", optional = true }

--- a/lcm-rust/lcm/src/error.rs
+++ b/lcm-rust/lcm/src/error.rs
@@ -1,0 +1,13 @@
+error_chain!{
+    errors {
+        FailedToInitialize {}
+        FailedToUnsubscribe {}
+        FailedToPublish {}
+        Timeout {}
+        InternalError {}
+    }
+
+    foreign_links {
+        Io(::std::io::Error);
+    }
+}

--- a/lcm-rust/lcm/src/lcm.rs
+++ b/lcm-rust/lcm/src/lcm.rs
@@ -1,4 +1,4 @@
-use std::io::{Error, ErrorKind, Result};
+use error::{ErrorKind, Result};
 use std::ffi::CString;
 use message::Message;
 use std::cmp::Ordering;
@@ -35,7 +35,7 @@ impl Lcm {
         trace!("Creating LCM instance");
         let lcm = unsafe { lcm_create(ptr::null()) };
         match lcm.is_null() {
-            true => Err(Error::new(ErrorKind::Other, "Failed to initialize LCM.")),
+            true => Err(ErrorKind::FailedToInitialize.into()),
             false => {
                 Ok(Lcm {
                     lcm: lcm,
@@ -117,7 +117,7 @@ impl Lcm {
 
         match result {
             0 => Ok(()),
-            _ => Err(Error::new(ErrorKind::Other, "LCM: Failed to unsubscribe")),
+            _ => Err(ErrorKind::FailedToUnsubscribe.into())
         }
     }
 
@@ -141,7 +141,7 @@ impl Lcm {
         };
         match result {
             0 => Ok(()),
-            _ => Err(Error::new(ErrorKind::Other, "LCM Error")),
+            _ => Err(ErrorKind::FailedToPublish.into())
         }
     }
 
@@ -161,7 +161,7 @@ impl Lcm {
         let result = unsafe { lcm_handle(self.lcm) };
         match result {
             0 => Ok(()),
-            _ => Err(Error::new(ErrorKind::Other, "LCM Error")),
+            _ => Err(ErrorKind::InternalError.into())
         }
     }
 
@@ -182,8 +182,8 @@ impl Lcm {
     pub fn handle_timeout(&mut self, timeout: Duration) -> Result<()> {
         let result = unsafe { lcm_handle_timeout(self.lcm, (timeout.as_secs() * 1000) as i32 + (timeout.subsec_nanos() / 1000_000) as i32) };
         match result.cmp(&0) {
-            Ordering::Less => Err(Error::new(ErrorKind::Other, "LCM Error")),
-            Ordering::Equal => Err(Error::new(ErrorKind::Other, "LCM Timeout")),
+            Ordering::Less => Err(ErrorKind::InternalError.into()),
+            Ordering::Equal => Err(ErrorKind::Timeout.into()),
             Ordering::Greater => Ok(()),
         }
     }

--- a/lcm-rust/lcm/src/lib.rs
+++ b/lcm-rust/lcm/src/lib.rs
@@ -11,6 +11,9 @@
 
 extern crate byteorder;
 
+#[macro_use]
+extern crate error_chain;
+
 #[cfg(feature = "log")]
 #[macro_use]
 extern crate log;
@@ -19,6 +22,8 @@ extern crate log;
 macro_rules! trace { ($($a:tt)*) => ( () ) }
 #[cfg(not(feature = "log"))]
 macro_rules! error { ($($a:tt)*) => ( () ) }
+
+mod error;
 
 mod ffi;
 


### PR DESCRIPTION
Without this change, it is difficult to determine whether `Lcm::handle_timeout` returned an actual error or just a timeout error.

I'll fix the merge conflicts sometime this week, when I have time.